### PR TITLE
Enable feedthrough input to the controller

### DIFF
--- a/flightlib/include/flightlib/envs/vision_env/vision_env.hpp
+++ b/flightlib/include/flightlib/envs/vision_env/vision_env.hpp
@@ -206,6 +206,7 @@ class VisionEnv final : public EnvBase {
   std::string obstacle_cfg_path_;
   int num_dynamic_objects_;
   int num_static_objects_;
+  bool control_feedthrough_;
 
   int collide_num;
   int time_num;

--- a/flightlib/src/envs/vision_env/vision_env.cpp
+++ b/flightlib/src/envs/vision_env/vision_env.cpp
@@ -55,6 +55,8 @@ void VisionEnv::init() {
   // load parameters
   loadParam(cfg_);
 
+  control_feedthrough_ = cfg_["environment"]["control_feedthrough"];
+
   // add camera
   if (!configCamera(cfg_)) {
     logger_.error(
@@ -376,10 +378,17 @@ bool VisionEnv::step(const Ref<Vector<>> act, Ref<Vector<>> obs,
 
   Vector<3> euler = quad_state_.Euler();
 
+  if (control_feedthrough_) {
+    cmd_.p = act.segment<3>(0);
+    cmd_.v = act.segment<3>(3);
+    cmd_.yaw = act(6);
 
-  cmd_.p = pi_act_.segment<3>(0) + quad_state_.p;
-  cmd_.v = pi_act_.segment<3>(3) + quad_state_.v;
-  cmd_.yaw = pi_act_(6) + euler[2];
+  } else {
+    cmd_.p = pi_act_.segment<3>(0) + quad_state_.p;
+    cmd_.v = pi_act_.segment<3>(3) + quad_state_.v;
+    cmd_.yaw = pi_act_(6) + euler[2];
+  }
+
 
   // simulate quadrotor
   quad_ptr_->run(cmd_, sim_dt_);

--- a/flightpy/configs/vision/config.yaml
+++ b/flightpy/configs/vision/config.yaml
@@ -6,6 +6,7 @@ environment:
   max_detection_range: 10.0
   goal: 70
   fly_result: yes
+  control_feedthrough: false
 # three difficulty level [easy, medium, hard](list when they learn)
 # configurations for dynamic and static obstacles, environment_(0~100)
 # Bounding box applied during training, exiting this box terminates the episode. [xmin, xmax, ymin, ymax, zmin, zmax]


### PR DESCRIPTION
This is a simple patch to enable feed the intput in to the controller without the postprocess. This can help us easily test the performance of the controller without the learning action.