### PR TITLE
Introduce the flight control that is used in jsk_aerial_robot

### DIFF
--- a/flightlib/include/flightlib/common/command.hpp
+++ b/flightlib/include/flightlib/common/command.hpp
@@ -41,8 +41,8 @@ class Command {
   /// Collective mass-normalized thrust in [m/s^2]
   Scalar collective_thrust;
 
-  /// Euler
-  Vector<3> euler;
+  /// Quaternion
+  Matrix<3, 3> R;
 
   /// Bodyrates in [rad/s]
   Vector<3> omega;

--- a/flightlib/include/flightlib/common/command.hpp
+++ b/flightlib/include/flightlib/common/command.hpp
@@ -9,7 +9,7 @@ namespace quadcmd {
 enum CMDMODE : int {
   SINGLEROTOR = 0,
   THRUSTRATE = 1,
-  LINVEL = 2,
+  THRUSTATT = 2,
 };
 
 }  // namespace quadcmd
@@ -24,12 +24,13 @@ class Command {
   bool valid() const;
   bool isSingleRotorThrusts() const;
   bool isThrustRates() const;
-  bool isLinerVel() const;
+  bool isThrustAttitude() const;
+  bool needPositionControl() const;
 
   //
   void setZeros(void);
-  void setCmdVector(const Vector<4>& cmd);
   bool setCmdMode(const int cmd_mode);
+  void setPostionControl(const bool flag);
 
   /// time in [s]
   Scalar t;
@@ -39,6 +40,9 @@ class Command {
 
   /// Collective mass-normalized thrust in [m/s^2]
   Scalar collective_thrust;
+
+  /// Euler
+  Vector<3> euler;
 
   /// Bodyrates in [rad/s]
   Vector<3> omega;
@@ -54,6 +58,7 @@ class Command {
 
   ///
   int cmd_mode;
+  bool need_position_control_;
 };
 
 }  // namespace flightlib

--- a/flightlib/include/flightlib/controller/lowlevel_controller_simple.hpp
+++ b/flightlib/include/flightlib/controller/lowlevel_controller_simple.hpp
@@ -22,8 +22,14 @@ class LowLevelControllerSimple {
   Matrix<4, 4> B_allocation_inv_;
 
   // P gain for body rate control
-  const Matrix<3, 3> Kinv_ang_vel_tau_ =
-    Vector<3>(20.0, 20.0, 40.0).asDiagonal();
+  Matrix<3, 3> Kp_rate_;
+
+  // P gain for euler attitude control,  D gain for body rate
+  Matrix<3, 3> Kp_euler_;
+  Matrix<3, 3> Kd_rate_;
+
+  // const Matrix<3, 3> Kinv_ang_vel_tau_ =
+  //   Vector<3>(20.0, 20.0, 40.0).asDiagonal();
 
   // Quadcopter to which the controller is applied
   QuadrotorDynamics quad_dynamics_;

--- a/flightlib/include/flightlib/controller/lowlevel_controller_simple.hpp
+++ b/flightlib/include/flightlib/controller/lowlevel_controller_simple.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "flightlib/common/command.hpp"
+#include "flightlib/common/quad_state.hpp"
 #include "flightlib/common/types.hpp"
 #include "flightlib/dynamics/quadrotor_dynamics.hpp"
 
@@ -12,7 +13,7 @@ class LowLevelControllerSimple {
 
   LowLevelControllerSimple(QuadrotorDynamics quad_dynamics);
   bool setCommand(const Command& cmd);
-  Vector<4> run(const Ref<Vector<3>> omega);
+  Vector<4> run(const QuadState& state);
   bool updateQuadDynamics(const QuadrotorDynamics& quad_dynamics);
 
  private:

--- a/flightlib/include/flightlib/dynamics/quadrotor_dynamics.hpp
+++ b/flightlib/include/flightlib/dynamics/quadrotor_dynamics.hpp
@@ -75,7 +75,9 @@ class QuadrotorDynamics : DynamicsBase {
   Vector<3> kdacc_;
   Scalar kpatt_z_;
   Scalar kpatt_xy_;
+  Vector<3> kpeuler_;
   Vector<3> kprate_;
+  Vector<3> kdrate_;
   Vector<3> p_err_max_;
   Vector<3> v_err_max_;
   Scalar filter_sampling_frequency_;

--- a/flightlib/include/flightlib/objects/quadrotor.hpp
+++ b/flightlib/include/flightlib/objects/quadrotor.hpp
@@ -34,6 +34,7 @@ class Quadrotor : ObjectBase {
   bool run(const Scalar dt) override;
   bool run(Command& cmd, const Scalar dt);
 
+  // outer loop controller
   bool updatePositionControl(const QuadState& state, Command& cmd);
 
   // public get functions

--- a/flightlib/include/flightlib/objects/quadrotor.hpp
+++ b/flightlib/include/flightlib/objects/quadrotor.hpp
@@ -34,10 +34,7 @@ class Quadrotor : ObjectBase {
   bool run(const Scalar dt) override;
   bool run(Command& cmd, const Scalar dt);
 
-
-  bool getTHRUSTRATEfromLINVEL(const QuadState& state, Command& cmd);
-    Vector<3> tiltPrioritizedControl(const Quaternion& q,
-                                   const Quaternion& q_des);
+  bool updatePositionControl(const QuadState& state, Command& cmd);
 
   // public get functions
   bool getState(QuadState* const state) const;
@@ -100,10 +97,6 @@ class Quadrotor : ObjectBase {
   Vector<4> motor_thrusts_;
   Matrix<4, 4> B_allocation_;
   Matrix<4, 4> B_allocation_inv_;
-
-  // P gain for body-rate control
-  const Matrix<3, 3> Kinv_ang_vel_tau_ =
-    Vector<3>(16.6, 16.6, 5.0).asDiagonal();
 
   // gravity
   const Vector<3> gz_{0.0, 0.0, Gz};

--- a/flightlib/src/common/command.cpp
+++ b/flightlib/src/common/command.cpp
@@ -7,7 +7,6 @@ Command::Command()
   : t(0.0),
     thrusts(0.0, 0.0, 0.0, 0.0),
     collective_thrust(0.0),
-    euler(0.0, 0.0, 0.0),
     omega(0.0, 0.0, 0.0),
     p(0.0, 0.0, 0.0),
     v(0.0, 0.0, 0.0),
@@ -32,7 +31,7 @@ bool Command::valid() const {
   return std::isfinite(t) &&
          (
           (p.allFinite() && v.allFinite() && std::isfinite(yaw) && need_position_control_) ||
-          (std::isfinite(collective_thrust) && euler.allFinite() &&
+          (std::isfinite(collective_thrust) && R.allFinite() &&
            (cmd_mode == quadcmd::THRUSTATT)) ||
           (std::isfinite(collective_thrust) && omega.allFinite() &&
            (cmd_mode == quadcmd::THRUSTRATE)) ||
@@ -50,7 +49,7 @@ bool Command::isThrustRates() const {
 
 bool Command::isThrustAttitude() const {
   return (cmd_mode == quadcmd::THRUSTATT) &&
-         (std::isfinite(collective_thrust) && euler.allFinite());
+         (std::isfinite(collective_thrust) && R.allFinite());
 }
 
 bool Command::needPositionControl() const {
@@ -63,11 +62,12 @@ void Command::setZeros() {
   collective_thrust = 0;
   yaw = 0;
 
-  euler = Vector<3>::Zero();
+  R = Matrix<3, 3>::Zero();
   p = Vector<3>::Zero();
   v = Vector<3>::Zero();
   thrusts = Vector<4>::Zero();
   omega = Vector<3>::Zero();
+
 }
 
 }  // namespace flightlib

--- a/flightlib/src/controller/lowlevel_controller_simple.cpp
+++ b/flightlib/src/controller/lowlevel_controller_simple.cpp
@@ -30,14 +30,15 @@ bool LowLevelControllerSimple::setCommand(const Command& cmd) {
 }
 
 
-Vector<4> LowLevelControllerSimple::run(const Ref<Vector<3>> omega_des) {
+Vector<4> LowLevelControllerSimple::run(const QuadState& state) {
   Vector<4> motor_thrusts;
-  if (!cmd_.isSingleRotorThrusts()) {
+  if (cmd_.isThrustRates()) {
+    const Vector<3> omega = state.w;
     const Scalar force = quad_dynamics_.getMass() * cmd_.collective_thrust;
-    const Vector<3> omega_err = cmd_.omega - omega_des;
+    const Vector<3> omega_err = cmd_.omega - omega;
     const Vector<3> body_torque_des =
       quad_dynamics_.getJ() * Kinv_ang_vel_tau_ * omega_err +
-      omega_des.cross(quad_dynamics_.getJ() * omega_des);
+      omega.cross(quad_dynamics_.getJ() * omega);
     const Vector<4> thrust_torque(force, body_torque_des.x(),
                                   body_torque_des.y(), body_torque_des.z());
 

--- a/flightlib/src/controller/lowlevel_controller_simple.cpp
+++ b/flightlib/src/controller/lowlevel_controller_simple.cpp
@@ -11,6 +11,14 @@ bool LowLevelControllerSimple::updateQuadDynamics(
   quad_dynamics_ = quad;
   B_allocation_ = quad.getAllocationMatrix();
   B_allocation_inv_ = B_allocation_.inverse();
+
+  Kp_rate_ = quad.kprate_.asDiagonal();
+  Kd_rate_ = quad.kdrate_.asDiagonal();
+  Kp_euler_ = quad.kpeuler_.asDiagonal();
+
+  std::cout << "Kp_euler_: \n" << Kp_euler_ << std::endl;
+  std::cout << "Kd_rate_: \n" << Kd_rate_ << std::endl;
+
   return true;
 }
 
@@ -37,12 +45,29 @@ Vector<4> LowLevelControllerSimple::run(const QuadState& state) {
     const Scalar force = quad_dynamics_.getMass() * cmd_.collective_thrust;
     const Vector<3> omega_err = cmd_.omega - omega;
     const Vector<3> body_torque_des =
-      quad_dynamics_.getJ() * Kinv_ang_vel_tau_ * omega_err +
+      quad_dynamics_.getJ() * Kp_rate_ * omega_err +
       omega.cross(quad_dynamics_.getJ() * omega);
     const Vector<4> thrust_torque(force, body_torque_des.x(),
                                   body_torque_des.y(), body_torque_des.z());
 
     motor_thrusts = B_allocation_inv_ * thrust_torque;
+
+  } else if (cmd_.isThrustAttitude()) {
+
+    // simple attitude controller
+    // ICRA 2011, Minimum Snap Trajectory Generation and Control for Quadrotors, Mellinger
+
+    const Vector<3> omega = state.w;
+    const Scalar force = quad_dynamics_.getMass() * cmd_.collective_thrust;
+    const Matrix<3, 3> R = state.R();
+    const Matrix<3, 3> R_err = 0.5 * (cmd_.R.transpose() * R - R.transpose() * cmd_.R);
+    const Vector<3> euler_err(-R_err(2, 1), -R_err(0, 2), -R_err(1, 0));
+    const Vector<3> body_torque_des = quad_dynamics_.getJ() * (Kp_euler_ * euler_err - Kd_rate_ * omega); // we ignore term of  wxJw
+    const Vector<4> thrust_torque(force, body_torque_des.x(),
+                                  body_torque_des.y(), body_torque_des.z());
+
+    motor_thrusts = B_allocation_inv_ * thrust_torque;
+
   } else {
     motor_thrusts = cmd_.thrusts;
   }

--- a/flightlib/src/dynamics/quadrotor_dynamics.cpp
+++ b/flightlib/src/dynamics/quadrotor_dynamics.cpp
@@ -295,6 +295,8 @@ bool QuadrotorDynamics::updateParams(const YAML::Node& params) {
   kpatt_z_ = params["Control"]["kpatt_z"].as<Scalar>();
   kpatt_xy_ = params["Control"]["kpatt_xy"].as<Scalar>();
   kprate_ = Map<Vector<3>>(params["Control"]["kprate"].as<std::vector<Scalar>>().data());
+  kdrate_ = Map<Vector<3>>(params["Control"]["kdrate"].as<std::vector<Scalar>>().data());
+  kpeuler_ = Map<Vector<3>>(params["Control"]["kpeuler"].as<std::vector<Scalar>>().data());
   p_err_max_ = Map<Vector<3>>(params["Control"]["p_err_max"].as<std::vector<Scalar>>().data());
   v_err_max_ = Map<Vector<3>>(params["Control"]["v_err_max"].as<std::vector<Scalar>>().data());
   filter_sampling_frequency_ = 

--- a/flightlib/src/envs/vision_env/vision_env.cpp
+++ b/flightlib/src/envs/vision_env/vision_env.cpp
@@ -55,7 +55,10 @@ void VisionEnv::init() {
   // load parameters
   loadParam(cfg_);
 
+  // additional paramter load
   control_feedthrough_ = cfg_["environment"]["control_feedthrough"];
+  cmd_.setCmdMode(cfg_["Control"]["cmd_mode"].as<int>());
+  cmd_.setPostionControl(cfg_["Control"]["position_control"]);
 
   // add camera
   if (!configCamera(cfg_)) {
@@ -98,32 +101,15 @@ bool VisionEnv::reset(Ref<Vector<>> obs) {
   quad_state_.x(QS::POSY) = uniform_dist_(random_gen_) * 9.0;
   quad_state_.x(QS::POSZ) = uniform_dist_(random_gen_) * 4 + 5.0;
 
-  // quad_state_.x(QS::POSX) = 0;
-  // quad_state_.x(QS::POSY) = 0;
-  // quad_state_.x(QS::POSZ) = 1;
-  // // set initial position is fixed
-
   // reset quadrotor with random states
   quad_ptr_->reset(quad_state_);
 
   // reset control command
-  cmd_.t = 0.0;
-  // use collective thrust and bodyrate control mode
-  cmd_.setCmdMode(quadcmd::LINVEL);
-  cmd_.collective_thrust = 0;
-  cmd_.omega.setZero();
-  cmd_.p.setZero();
-  cmd_.v.setZero();
-  cmd_.yaw = 0;
-
-  // std::cout << "setting cmd is finished" << std::endl;
-
+  cmd_.setZeros();
 
   // changeLevel();
   // obtain observations
   getObs(obs);
-  // std::cout <<"call reset" << std::endl;
-  // std::cout << "reset in VisionEnv is finished" << std::endl;
   return true;
 }
 

--- a/flightlib/src/objects/quadrotor.cpp
+++ b/flightlib/src/objects/quadrotor.cpp
@@ -35,24 +35,15 @@ Quadrotor::Quadrotor(const QuadrotorDynamics &dynamics)
 Quadrotor::~Quadrotor() {}
 
 bool Quadrotor::run(Command &cmd, const Scalar ctl_dt) {
-  // change LINVEL cmd -> THRUSTRATE cmd
-  // std::cout << "cmd.p is " << cmd.p << std::endl;
-  // std::cout << "cmd.v is " << cmd.v << std::endl;
-  // std::cout << "cmd.yaw is " << cmd.yaw << std::endl;
-  // std::cout << "cmd.isLinerVel is " << cmd.isLinerVel() << std::endl;
 
   if (cmd.isLinerVel()) {
-    getTHRUSTRATEfromLINVEL(state_, cmd);
-    // std::cout << "cmd.collective_thrust is " << cmd.collective_thrust
-    // << std::endl;
-    // std::cout << "cmd.omega is " << cmd.omega << std::endl;
+    updatePositionControl(state_, cmd);
   }
+
   if (!setCommand(cmd)) {
     logger_.error("Cannot Set Control Command");
     return false;
   };
-  // std::cout << cmd_.collective_thrust << std::endl;
-  // std::cout << cmd_.omega << std::endl;
   return run(ctl_dt);
 }
 
@@ -117,111 +108,34 @@ bool Quadrotor::run(const Scalar ctl_dt) {
   return true;
 }
 
-bool Quadrotor::getTHRUSTRATEfromLINVEL(const QuadState &state, Command &cmd) {
-  // if (setpoints == nullptr) return false;
-  // setpoints->clear();
+bool Quadrotor::updatePositionControl(const QuadState &state, Command &cmd) {
 
   if (!state.valid()) {
-    // logger_.error("Control inputs are not valid!");
     std::cout << "State is invalid" << std::endl;
-    // logger_.error("Setpoints are empty: [%d]!", references.empty());
-    // logger_.error("Setpoint is valid: [%d]!",
-    // references.front().input.valid()); logger_ << references.front().input;
     return false;
   }
-  // There is function "valid" in class
 
   // acc command
-  Vector<3> acc_cmd;
-  {
-    Vector<3> pos_error = clip(
-      cmd.p - state.p, dynamics_.p_err_max_);  // set clipping for stable flight
-    // Vector<3> pos_error = cmd.p - state.p;  // eliminate clipping
-    // setpoint.state.p comes from action
-    // if I want to reduce action dimention, transplant navigation system in ROS
-    // sim to this sim
-    Vector<3> vel_error = clip(cmd.v - state.v, dynamics_.v_err_max_);
-
-    Vector<3> acc_setpoint = {0, 0, 0};  // set 0
-
-    acc_cmd = dynamics_.kpacc_.cwiseProduct(pos_error) +
-              dynamics_.kdacc_.cwiseProduct(vel_error) + acc_setpoint - GVEC;
-    // std::cout << "acc_cmd: " << acc_cmd << std::endl;
-    if (acc_cmd[2] < 1) acc_cmd[2] = 1;  // if 0, then unstable in z_B
-    // std::cout << "acc_cmd: " << acc_cmd << std::endl;
-    //
-
-    // if (params_->drag_compensation_ && state.v.norm() > 3.0) {
-    //   const Vector<3> acc_aero =
-    //     state.q() * (thrust_f * Vector<3>::UnitZ() / quad_.m_ - acc_f);
-    //   acc_cmd += acc_aero;
-    // }
-  }
-  const Scalar thrust_cmd = acc_cmd.norm() * dynamics_.getMass();
+  Vector<3> pos_error = clip(cmd.p - state.p, dynamics_.p_err_max_);  // set clipping for stable flight
+  Vector<3> vel_error = clip(cmd.v - state.v, dynamics_.v_err_max_);
+  Vector<3> acc_setpoint = {0, 0, 0};  // set 0
+  Vector<3> acc_cmd = dynamics_.kpacc_.cwiseProduct(pos_error) +
+    dynamics_.kdacc_.cwiseProduct(vel_error) + acc_setpoint - GVEC;
+  if (acc_cmd[2] < 1) acc_cmd[2] = 1;  // if 0, then unstable in z_B
+  Scalar thrust_cmd = acc_cmd.norm() * dynamics_.getMass();
 
   // attitude command
-  Quaternion q_cmd;
-  {
-    const Quaternion q_c(
-      Quaternion(Eigen::AngleAxis<Scalar>(cmd.yaw, Vector<3>::UnitZ())));
-    // std::cout << "q_c: " << q_c.w() << "," << q_c.x() << "," << q_c.y() <<
-    // ","
-    //           << q_c.z() << std::endl;
-    const Vector<3> y_c = q_c * Vector<3>::UnitY();
-    // std::cout << "y_c: " << y_c << std::endl;
-    const Vector<3> z_B =
-      acc_cmd.normalized();  // normalized desired z direction vector
-    // std::cout << "z_B: " << z_B << std::endl;
-    const Vector<3> x_B = (y_c.cross(z_B)).normalized();  // normalized vector
-    // std::cout << "x_B: " << x_B << std::endl;
-    const Vector<3> y_B = (z_B.cross(x_B)).normalized();
-    // std::cout << "y_B: " << y_B << std::endl;
-    const Matrix<3, 3> R_W_B((Matrix<3, 3>() << x_B, y_B, z_B).finished());
-    const Quaternion q_des(R_W_B);
-
-    q_cmd = q_des;  // desired quaternion by cmd.yaw and acc_cmd
-  }
+  Quaternion q_c(Quaternion(Eigen::AngleAxis<Scalar>(cmd.yaw, Vector<3>::UnitZ())));
+  Vector<3> y_c = q_c * Vector<3>::UnitY();
+  Vector<3> z_B = acc_cmd.normalized();  // normalized desired z direction vector
+  Vector<3> x_B = (y_c.cross(z_B)).normalized();  // normalized vector
+  Vector<3> y_B = (z_B.cross(x_B)).normalized();
+  Matrix<3, 3> R_W_B((Matrix<3, 3>() << x_B, y_B, z_B).finished());
+  Quaternion q_des(R_W_B);  // desired quaternion by cmd.yaw and acc_cmd
 
   // angular acceleration command
-  // Vector<3> alpha_cmd;
-  Vector<3> omega_cmd;
-  {
-    // std::cout << "q_cmd: " << q_cmd.w() << "," << q_cmd.x() << "," <<
-    // q_cmd.y()
-    //           << "," << q_cmd.z() << std::endl;
-    omega_cmd = tiltPrioritizedControl(state.q(), q_cmd);
-
-    // // angular rate / acceleration reference from Mellinger 2011
-    // // calc tau
-    // const Vector<3> bx = state.q() * Vector<3>::UnitX();
-    // const Vector<3> by = state.q() * Vector<3>::UnitY();
-    // const Vector<3> bz = state.q() * Vector<3>::UnitZ();
-    // Vector<3> hw =
-    //   dynamics_.getMass() * (setpoint.state.j - bz.dot(setpoint.state.j) *
-    //   bz);
-    // if (thrust_f >= 0.01) hw /= thrust_f;
-    // const Vector<3> w_ref =
-    //   Vector<3>(-hw.dot(by), hw.dot(bx), setpoint.state.w(2));
-
-    // alpha_cmd = omega_cmd + params_->kp_rate_.cwiseProduct(w_ref - state.w);
-  }
-
-  // QuadState state_cmd = state;
-  // state_cmd.tau = alpha_cmd; //I cannot image how it works...
-  // Command command;
-  cmd.t = state.t;
-  cmd.omega = omega_cmd;
-  cmd.collective_thrust = thrust_cmd / dynamics_.getMass();
-  // be careful cmd.cmd_mode stays "2"
-  //  setpoints->push_back({state_cmd, command});
-
-  return true;
-}
-
-Vector<3> Quadrotor::tiltPrioritizedControl(const Quaternion &q,
-                                            const Quaternion &q_des) {
   // Attitude control method from Fohn 2020.
-  const Quaternion q_e = q.inverse() * q_des;
+  const Quaternion q_e = state.q().inverse() * q_des;
 
   Matrix<3, 3> T_att = (Matrix<3, 3>() << dynamics_.kpatt_xy_, 0.0, 0.0, 0.0,
                         dynamics_.kpatt_xy_, 0.0, 0.0, 0.0, dynamics_.kpatt_z_)
@@ -229,10 +143,14 @@ Vector<3> Quadrotor::tiltPrioritizedControl(const Quaternion &q,
   Vector<3> tmp = Vector<3>(q_e.w() * q_e.x() - q_e.y() * q_e.z(),
                             q_e.w() * q_e.y() + q_e.x() * q_e.z(), q_e.z());
   if (q_e.w() <= 0) tmp(2) *= -1.0;
-  const Vector<3> rate_cmd =
-    2.0 / std::sqrt(q_e.w() * q_e.w() + q_e.z() * q_e.z()) * T_att * tmp;
+  Vector<3> omega_cmd = 2.0 / std::sqrt(q_e.w() * q_e.w() + q_e.z() * q_e.z()) * T_att * tmp;
 
-  return rate_cmd;
+  // Command command;
+  cmd.t = state.t;
+  cmd.omega = omega_cmd;
+  cmd.collective_thrust = thrust_cmd / dynamics_.getMass();
+
+  return true;
 }
 
 void Quadrotor::init() {

--- a/flightlib/src/objects/quadrotor.cpp
+++ b/flightlib/src/objects/quadrotor.cpp
@@ -153,7 +153,8 @@ bool Quadrotor::updatePositionControl(const QuadState &state, Command &cmd) {
   }
 
   if (cmd.isThrustAttitude()) {
-    cmd.euler = q_des.toRotationMatrix().eulerAngles(0, 1, 2);
+    cmd.R = q_des.toRotationMatrix();
+    // std::cout << "cmd.q: " << q_des.x() << "," << q_des.y() << ", " << q_des.z() << ", " << q_des.w() << "; cmd_euler: " << cmd.R.eulerAngles(2, 1, 0).transpose()  << "; euler: " << state_.Euler().transpose() << std::endl;
   }
 
   return true;

--- a/flightpy/configs/vision/config.yaml
+++ b/flightpy/configs/vision/config.yaml
@@ -79,14 +79,16 @@ quadrotor_dynamics:
   body_drag_h: 0.00
 
 Control:
-  cmd_mode:                     1 # please check flightmare/flightlib/include/flightlib/common/command.hpp#9-13
+  cmd_mode:                     2 # please check flightmare/flightlib/include/flightlib/common/command.hpp#9-13
   position_control:             true # whether need position control
   drag_compensation:            false
   kpacc:                        [10.0,  10.0, 20.0]
   kdacc:                        [ 4.0,   4.0,  6.0]
   kpatt_z:                      2
   kpatt_xy:                     10
-  kprate:                       [0.0, 0.0, 0.0]
+  kprate:                       [20.0, 20.0, 40.0]
+  kpeuler:                      [200.0, 200.0, 100.0]
+  kdrate:                       [20.0, 20.0, 40.0]
   p_err_max:                    [0.6, 0.6, 0.3]
   v_err_max:                    [1.0, 1.0, 1.0]
   filter_sampling_frequency:     300   # filter frequency, same as control frequency (Hz)

--- a/flightpy/configs/vision/config.yaml
+++ b/flightpy/configs/vision/config.yaml
@@ -79,6 +79,8 @@ quadrotor_dynamics:
   body_drag_h: 0.00
 
 Control:
+  cmd_mode:                     1 # please check flightmare/flightlib/include/flightlib/common/command.hpp#9-13
+  position_control:             true # whether need position control
   drag_compensation:            false
   kpacc:                        [10.0,  10.0, 20.0]
   kdacc:                        [ 4.0,   4.0,  6.0]


### PR DESCRIPTION
The main modification is that I add the attitude control based on rotation matrix:
https://github.com/tongtybj/flightmare/blob/41ebacb2f402200c803e1c430c9aa6a84abf9dd2/flightlib/src/controller/lowlevel_controller_simple.cpp#L57-L67

This part is based on Eq.8 of https://ieeexplore.ieee.org/document/5980409.

We have two control modes now:
https://github.com/tongtybj/flightmare/blob/41ebacb2f402200c803e1c430c9aa6a84abf9dd2/flightpy/configs/vision/config.yaml#L82

- `1: THRUSTRATES`
- `2: THRUSTATTITUDE`  (new)

The default mode rightnow is `2`. 
You can test this control mode with `agileflight` with following command:

```bash
$ python -m python.run_control
```
(Please read https://github.com/HarukiKozukapenguin/agile_flight/pull/1 for more detail about this command)

